### PR TITLE
use specific version in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a fork of the official GitHub [actions/setup-node](https://github.com/ma
 
 ```yaml
 - name: Setup node
-  uses: guardian/actions-setup-node@main
+  uses: guardian/actions-setup-node@v2.4.1
 ```
 
 It checks the following places:


### PR DESCRIPTION
## What does this change?

This PR updates the usage example shown in the README to target a specific version of the action as this is GitHub's recommendation.